### PR TITLE
fix: Target correct table in scraper to resolve data corruption

### DIFF
--- a/Leo_ticker_sourcing.py
+++ b/Leo_ticker_sourcing.py
@@ -19,7 +19,8 @@ def get_sp500_tickers():
         resp = requests.get('http://en.wikipedia.org/wiki/List_of_S%26P_500_companies')
         resp.raise_for_status()  # Raise an exception for bad status codes
         soup = bs.BeautifulSoup(resp.text, 'lxml')
-        table = soup.find('table', {'class': 'wikitable sortable'})
+        # Find the correct table by its unique ID, which is more robust than using class names
+        table = soup.find('table', {'id': 'constituents'})
 
         tickers = []
         for row in table.findAll('tr')[1:]:


### PR DESCRIPTION
This commit provides a critical fix to the web scraper in `Leo_ticker_sourcing.py`.

The previous implementation used a generic class name to find the S&P 500 table on Wikipedia, which caused it to incorrectly scrape data from a "Recent Changes" table, leading to data corruption (dates being imported as tickers) and an incomplete list of stocks.

This fix changes the scraper to target the table by its unique HTML ID (`id="constituents"`), ensuring that only the correct list of S&P 500 companies is parsed. This resolves the root cause of all downstream errors, including failed data downloads and empty indicator calculations.