### PR TITLE
fix: Handle multi-level columns from yfinance

### DIFF
--- a/Leo_data_ingestion.py
+++ b/Leo_data_ingestion.py
@@ -72,6 +72,12 @@ def prepare_data_for_db(df, stock_id):
         pandas.DataFrame: The formatted DataFrame.
     """
     df = df.copy()
+
+    # yfinance returns a multi-level column index for single-ticker downloads.
+    # This checks for that and flattens the columns to a single level.
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.droplevel(1)
+
     df.reset_index(inplace=True)
     df['stock_id'] = stock_id
 


### PR DESCRIPTION
This commit provides the final fix for a `KeyError` during data ingestion.

Diagnostic testing revealed that `yfinance` returns a DataFrame with a multi-level (hierarchical) column index when downloading data for a single ticker. The previous data preparation script was not designed to handle this format, causing it to fail when trying to find and rename columns.

This patch updates the `prepare_data_for_db` function in `Leo_data_ingestion.py` to detect and flatten the multi-level column index, making the data processing robust. This should be the final fix required to allow the data pipeline to run to completion.