### PR TITLE
fix: Use SQLAlchemy text() for raw SQL execution

### DIFF
--- a/Leo_data_ingestion.py
+++ b/Leo_data_ingestion.py
@@ -5,6 +5,7 @@
 import yfinance as yf
 import pandas as pd
 from datetime import datetime
+from sqlalchemy import text
 import Leo_connection
 
 def get_tickers_from_db():
@@ -133,7 +134,7 @@ def store_prices_to_db(df):
                 SELECT stock_id, price_date, open_price, high_price, low_price, close_price, adj_close_price, volume
                 FROM {temp_table_name};
                 """
-                result = conn.execute(insert_sql)
+                result = conn.execute(text(insert_sql))
                 print(f"Successfully inserted {result.rowcount} new price records.")
 
                 # Drop the temporary table

--- a/Leo_indicator_calculation.py
+++ b/Leo_indicator_calculation.py
@@ -5,6 +5,7 @@
 import pandas as pd
 import pandas_ta as ta
 import Leo_connection
+from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 def get_stocks_to_process():
@@ -131,7 +132,7 @@ def store_indicators_to_db(df):
         # Delete existing records to prevent duplicates and ensure fresh data
         if stock_price_ids:
             delete_query = f"DELETE FROM technical_indicators WHERE stock_price_id IN ({','.join(map(str, stock_price_ids))})"
-            session.execute(delete_query)
+            session.execute(text(delete_query))
 
         # Insert new records
         df.to_sql('technical_indicators', engine, if_exists='append', index=False)


### PR DESCRIPTION
This commit fixes a `Not an executable object` error that occurred during database insertion and deletion operations.

The error was caused by passing raw SQL strings directly to SQLAlchemy's `execute()` method. Modern versions of SQLAlchemy require these strings to be wrapped in the `text()` construct for security and compatibility.

This patch updates both `Leo_data_ingestion.py` and `Leo_indicator_calculation.py` to correctly use `text()`, which should resolve the final database errors and allow the pipeline to run to completion.