### PR TITLE
fix: Wrap DROP TABLE statement in text() to prevent error

### DIFF
--- a/Leo_data_ingestion.py
+++ b/Leo_data_ingestion.py
@@ -137,8 +137,8 @@ def store_prices_to_db(df):
                 result = conn.execute(text(insert_sql))
                 print(f"Successfully inserted {result.rowcount} new price records.")
 
-                # Drop the temporary table
-                conn.execute(f"DROP TABLE {temp_table_name}")
+                # Drop the temporary table, ensuring it's also a text object
+                conn.execute(text(f"DROP TABLE {temp_table_name}"))
 
     except Exception as e:
         print(f"An error occurred during database insertion: {e}")


### PR DESCRIPTION
This commit provides the final fix for the data ingestion pipeline.

A `Not an executable object` error was occurring on the `DROP TABLE` command, which was an oversight from the previous fix. This patch wraps the raw SQL `DROP TABLE` string in SQLAlchemy's `text()` construct, which is required for execution.

This should resolve the final known bug and allow the entire pipeline to run to completion.