### PR TITLE
fix: Use app.run instead of obsolete app.run_server

### DIFF
--- a/Leo_dashboard.py
+++ b/Leo_dashboard.py
@@ -153,4 +153,4 @@ def update_database_callback(n_clicks):
 if __name__ == '__main__':
     # Note: For production, use a proper WSGI server like Gunicorn or Waitress
     # Example: gunicorn Leo_dashboard:server -b 0.0.0.0:8090
-    app.run_server(debug=True, host='0.0.0.0', port=8090)
+    app.run(debug=True, host='0.0.0.0', port=8090)


### PR DESCRIPTION
This commit provides a fix for an `ObsoleteAttributeException` that occurred when starting the Dash application.

The error was caused by using `app.run_server()`, which has been deprecated in newer versions of Dash.

This patch updates the application startup command in `Leo_dashboard.py` to use the new, correct method: `app.run()`. This should resolve the final startup error.